### PR TITLE
Feature/implementation

### DIFF
--- a/lib/model_object.js
+++ b/lib/model_object.js
@@ -24,7 +24,7 @@ function ModelObject(options) {
         this.uuid = uuid.v4();
     }
 
-    this.scope = null;
+    this.scope = options.scope instanceof Scope ? options.scope : null;
     this.isScopeRoot = false;
     this._resolvedProperties = null;
     this._resolvedPropertiesLookup = null;
@@ -110,11 +110,27 @@ ModelObject._addSubtype = function(typeClass) {
     }
     if (!this._subtypesByTypeName[this.typeName][typeClass.typeName]) {
         this._subtypesByTypeName[this.typeName][typeClass.typeName] = typeClass;
+
+        // Add all of the subtype's children subtypes as well
+        typeClass._getSubtypes().forEach(this._addSubtype.bind(this));
     }
     var supertype = this._getSupertype();
     if (supertype) {
         supertype._addSubtype(typeClass);
     }
+};
+
+ModelObject._getSubtypes = function() {
+    var subtypesLookup = ModelObject._subtypesByTypeName[this.typeName];
+    if (!subtypesLookup) {
+        return [];
+    }
+
+    var subtypes = [];
+    Object.keys(subtypesLookup).forEach(function(key) {
+        subtypes.push(subtypesLookup[key]);
+    });
+    return subtypes;
 };
 
 ModelObject._getSubtypeWithTypeName = function(typeName) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -435,7 +435,11 @@ Scope.prototype._temporalModelObjectForAddSyncFragment = function(fragment, call
             var modelObject;
             try {
                 var Type = modelObjectType;
-                modelObject = new Type({uuid: fragment.objectUUID});
+                var uuid = fragment.objectUUID;
+                modelObject = new Type({
+                    uuid: uuid,
+                    scope: this
+                });
             } catch (err) {
                 return nextCallback(err);
             }


### PR DESCRIPTION
- Move recursive model object lookup to ModelObject class for re-use
- Add all subtype's children subtypes to supertype when adding subtype to supertype
- Set the scope for temporal objects created for add sync fragments
